### PR TITLE
Capture R_LIBS_SITE and PYTHONPATH at configure time.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *~
 
 # autoconf generated files
+qsub-template.sh
 configure
 config.status
 config.log

--- a/Makefile.am
+++ b/Makefile.am
@@ -4,7 +4,8 @@ nodist_bin_SCRIPTS = \
   pigx-chipseq
 
 dist_pkglibexec_SCRIPTS = \
-  Snake_ChIPseq.py
+  Snake_ChIPseq.py \
+  qsub-template.sh
 
 pkglibexec_scriptsdir = $(pkglibexecdir)/scripts
 dist_pkglibexec_scripts_SCRIPTS =		\

--- a/configure.ac
+++ b/configure.ac
@@ -104,9 +104,21 @@ AX_COMPARE_VERSION([$SAMTOOLS_VERSION], [lt], [$SAMTOOLS_VERSION_MIN],
       [AC_MSG_ERROR([Please install Samtools $SAMTOOLS_VERSION_MIN.])])
   ])
 
+AC_ARG_ENABLE([environment-capture],
+  AS_HELP_STRING([--disable-environment-capture], [Do not capture environment variables.]),
+  [AC_MSG_NOTICE([Environment variables will not be captured.])],
+  [dnl
+AC_MSG_NOTICE([Environment variables will be captured.])
+capture_environment=yes
+AC_ARG_VAR(R_LIBS_SITE, The search path for all R packages)
+AC_ARG_VAR(PYTHONPATH, The search path for all Python packages)
+  ])
+
+AC_SUBST([capture_environment])
 AC_CONFIG_FILES([etc/settings.yaml
                  scripts/Sample_Report.rmd
-                 Makefile])
+                 Makefile
+                 qsub-template.sh])
 AC_CONFIG_FILES([Tests/test.sh], [chmod +x Tests/test.sh])
 AC_CONFIG_FILES([pigx-chipseq], [chmod +x pigx-chipseq])
 AC_OUTPUT

--- a/pigx-chipseq.in
+++ b/pigx-chipseq.in
@@ -19,7 +19,17 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-
+if 'yes' == '@capture_environment@':
+    import os, sys
+    os.environ["R_LIBS_SITE"] = "@R_LIBS_SITE@"
+    os.environ["PYTHONPATH"] = "@PYTHONPATH@"
+    # Setting PYTHONPATH does not help with dependencies needed for
+    # this script.
+    for directory in "@PYTHONPATH@".split(":"):
+        try:
+            sys.path.index(directory)
+        except ValueError:
+            sys.path.insert(1, directory)
 
 
 import argparse
@@ -368,12 +378,13 @@ if config['execution']['submit-to-cluster']:
             exit(1)
         else:
             raise
-    qsub = "qsub -V -l h_stack={cluster.h_stack}  -l h_vmem={cluster.MEM} %s -b y -pe smp {cluster.nthreads} -cwd" % contact_email_string
+    qsub = "qsub -v R_LIBS_USER -v PATH -v GUIX_LOCPATH -l h_stack={cluster.h_stack}  -l h_vmem={cluster.MEM} %s -b y -pe smp {cluster.nthreads} -cwd" % contact_email_string
     if config['execution']['cluster']['args']:
         qsub += " " + config['execution']['cluster']['args']
     command += [
         "--cluster-config={}".format(cluster_config_file),
         "--cluster={}".format(qsub),
+        "--jobscript={}/qsub-template.sh".format(config['locations']['pkglibexecdir']),
         "--latency-wait={}".format(config['execution']['cluster']['missing-file-timeout'])
     ]
 else:

--- a/qsub-template.sh.in
+++ b/qsub-template.sh.in
@@ -1,0 +1,11 @@
+#!@GNUBASH@
+# properties = {properties}
+
+if [ 'yes' = '@capture_environment@' ]; then
+    export R_LIBS_SITE="@R_LIBS_SITE@"
+    export PYTHONPATH="@PYTHONPATH@"
+fi
+
+env
+
+{exec_job}


### PR DESCRIPTION
Restore these variables at runtime both for cluster submission and
local execution.  Remove "-V" flag from "qsub" command line to control
the environment more accurately with a jobscript template.

Only pass environment variables that have been modified by the driver
script (PATH and R_LIBS_USER) and GUIX_LOCPATH for convenience.