### PR TITLE
Peak Calling: infer genome size from the genome.chrlen.txt file itself

### DIFF
--- a/Rules/Peak_Calling.py
+++ b/Rules/Peak_Calling.py
@@ -20,7 +20,8 @@ def get_files_macs(wc):
 
 rule macs2:
     input:
-        unpack(get_files_macs)
+        unpack(get_files_macs),
+        chrlen = rules.index_to_chrlen.output
     output:
         outfile = os.path.join(PATH_PEAK, "{name}", "{name}_peaks.{class, narrow|broad}Peak")
     params:
@@ -49,9 +50,15 @@ rule macs2:
         if hasattr(input, 'Cont'):
             samples = samples + " ".join([' -c'] + input.Cont)
 
+        # define the genome size based on sum of length of chroms
+        with open(input.chrlen[0]) as f:
+            chrsize = [ int(line[1]) for line in csv.reader(f,delimiter="\t")]
+            gsize = sum( chrsize )
+
         command = " ".join(
         [params.macs2, 'callpeak',
         samples,
+        '--gsize',str(gsize),
         '--outdir', params.outpath,
         '-n', params.name,
         join_params("macs2", PARAMS, params_macs),

--- a/Tests/settings.yaml
+++ b/Tests/settings.yaml
@@ -16,7 +16,7 @@ general:
     idr:
         idr-threshold: 0.1
     macs2:
-        g: mm
+        #        g: mm
         keep-dup: auto
         q: 0.05
         nomodel: ''

--- a/Tests/settings_reduced.yaml
+++ b/Tests/settings_reduced.yaml
@@ -16,7 +16,7 @@ general:
     idr:
         idr-threshold: 0.1
     macs2:
-        g: mm
+        #        g: mm
         keep-dup: auto
         q: 0.05
         nomodel: ''

--- a/etc/settings.yaml.in
+++ b/etc/settings.yaml.in
@@ -23,7 +23,6 @@ general:
     idr:
         idr-threshold: 0.1
     macs2:
-        g:
         keep-dup: auto
         q: 0.05
     extract_signal:


### PR DESCRIPTION
- this removes the necessity to pass the g: option to macs2 (which is easily overseen)
- remove macs2 g-option from shipped settings files

Fixes https://github.com/BIMSBbioinfo/pigx_chipseq/issues/85