### PR TITLE
Fixes required for compilation of figure 6.1 and 8.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ installed:
     - crosstalk
     - gprofiler2
     - summarizedexperiment
+    - hexbin
 - python
     - snakemake
     - pyyaml

--- a/configure.ac
+++ b/configure.ac
@@ -101,6 +101,7 @@ AX_R_PACKAGE([crosstalk])
 AX_R_PACKAGE([gprofiler2])
 AX_R_PACKAGE([SummarizedExperiment])
 AX_R_PACKAGE([Rsubread])
+AX_R_PACKAGE([hexbin])
   ])
 
 

--- a/scripts/Sample_Report.rmd.in
+++ b/scripts/Sample_Report.rmd.in
@@ -541,9 +541,8 @@ dd = lstats$Peak_Statistics$peaks_sample %>%
   mutate(mapped_total = as.numeric(mapped_total)) %>%
   mutate(value      = round(value/mapped_total,2))
 
-dd$sample_cnt <- sub("*.sorted.bam", "", dd$sample_cnt)
-
 g = dd %>%
+  mutate(sample_cnt = gsub("*.sorted.bam", "", sample_cnt))  %>%
   dplyr::filter(bam_name == sample_cnt)                          %>%
   ggplot(aes(x = sample_name, y = value, fill=bam_name)) +
   geom_bar(stat='identity', position='dodge') +

--- a/scripts/Sample_Report.rmd.in
+++ b/scripts/Sample_Report.rmd.in
@@ -541,6 +541,8 @@ dd = lstats$Peak_Statistics$peaks_sample %>%
   mutate(mapped_total = as.numeric(mapped_total)) %>%
   mutate(value      = round(value/mapped_total,2))
 
+dd$sample_cnt <- sub("*.sorted.bam", "", dd$sample_cnt)
+
 g = dd %>%
   dplyr::filter(bam_name == sample_cnt)                          %>%
   ggplot(aes(x = sample_name, y = value, fill=bam_name)) +

--- a/scripts/Sample_Report.rmd.in
+++ b/scripts/Sample_Report.rmd.in
@@ -121,6 +121,7 @@ suppressPackageStartupMessages({
     library(ggplot2)
     library(heatmaply)
     library(plotly)
+    library(hexbin)
 })
 ```
 


### PR DESCRIPTION
#### What does this fix?
Correct compilation of figures '6.1 GC Content Distribution Per Sample' and '8.1 Frequency of reads in peaks'.
Dependencies of R libraries seem to have changed and naming convention of values of two columns in the generated R data frame does not seem to match anymore.

#### Changes 
Added:
  - dependency for R library hexbin to files configure.ac and README.md
   - loading of library hexbin in Sample_Report.rmd.in
   - added a line that renames values of the column dd\$sample_cnt to match the names of the values of the column dd\$bam_name (removes 'sorted.bam' from the names.) in Sample_Report.rmd.in

